### PR TITLE
Remove markdown conversion from mcp server

### DIFF
--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -20,7 +20,6 @@ except ImportError:
     import scraper
     extract_text_from_url = scraper.extract_text_from_url
 
-import markdownify
 
 logger = Logger(__name__)
 
@@ -148,9 +147,6 @@ async def serve(custom_user_agent: str | None = None):
             ))
 
         content = result.get("markdown_content")
-        if content:
-            content = markdownify.markdownify(
-                content, heading_style=markdownify.ATX)
 
         # Truncate if necessary
         if content and args.max_length is not None and len(content) > args.max_length:
@@ -199,9 +195,6 @@ async def serve(custom_user_agent: str | None = None):
             )
 
         content = result.get("markdown_content")
-        if content:
-            content = markdownify.markdownify(
-                content, heading_style=markdownify.ATX)
 
         logger.info(
             f"Successfully scraped {url} for prompt, returning {len(content) if content else 0} characters")


### PR DESCRIPTION
## Summary
- avoid double conversion by removing `markdownify` calls in `mcp_server`
- keep original markdown for truncation and messaging

## Testing
- `pytest -q tests/test_mcp_server.py`
- `pytest -q` *(fails: test_extract_text_from_example_com, test_extract_text_from_example_com_with_max_length, test_extract_text_from_wikipedia)*

------
https://chatgpt.com/codex/tasks/task_e_684b3040d3288333b8a2dd1dfd632d56